### PR TITLE
build: Upgrade Go setup to version 5 and change release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.21.0"
 
@@ -43,23 +43,9 @@ jobs:
           name: build-artifacts
           path: build/storage-x86_64-pc-windows-msvc.exe
 
-      - name: Create GitHub Release
-        id: create_release
-        uses: actions/create-release@v1
+      - name: Create and Upload Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: build/storage-x86_64-pc-windows-msvc.exe
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          draft: false
-          prerelease: false
-
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./build/storage-x86_64-pc-windows-msvc.exe
-          asset_name: storage-x86_64-pc-windows-msvc.exe
-          asset_content_type: application/octet-stream


### PR DESCRIPTION
Upgrade the Go setup to version 5 in the workflow file.
Switch from creating a GitHub release to using softprops/action-gh-release to
create and upload release assets.